### PR TITLE
jamf_ea_LatestOSSupported - check purgeable disk space

### DIFF
--- a/Jamf Pro/Extension Attributes/jamf_ea_LatestOSSupported.sh
+++ b/Jamf Pro/Extension Attributes/jamf_ea_LatestOSSupported.sh
@@ -48,7 +48,7 @@
 	systemRAM=$( /usr/sbin/sysctl -n hw.memsize )
 	RAMUpgradeable=$( /usr/sbin/system_profiler SPMemoryDataType | /usr/bin/awk -F "Upgradeable Memory: " '{print $2}' | /usr/bin/xargs )
 # Get free space on the boot disk
-	systemFreeSpace=$( /usr/sbin/diskutil info / | /usr/bin/awk -F '[()]' '/Free Space|Available Space/ {print $2}' | /usr/bin/cut -d " " -f1 )
+	systemFreeSpace=$( osascript -l 'JavaScript' -e "ObjC.import('Foundation'); var freeSpaceBytesRef=Ref(); $.NSURL.fileURLWithPath('/').getResourceValueForKeyError(freeSpaceBytesRef, 'NSURLVolumeAvailableCapacityForImportantUsageKey', null); Math.round(ObjC.unwrap(freeSpaceBytesRef[0]))" )
 
 ##################################################
 # Setup Functions


### PR DESCRIPTION
I saw some discussion in the MacAdmins slack, as well as the article here: https://scriptingosx.com/2021/11/the-unexpected-return-of-javascript-for-automation/ and the latest update to Grahm Pugh's erase-install script here: https://github.com/grahampugh/erase-install

It appears that by using JXA you can get a more accurate number including the purgeable space on the drive.